### PR TITLE
fix: handle files with zero length

### DIFF
--- a/onlyfans_scraper/utils/download.py
+++ b/onlyfans_scraper/utils/download.py
@@ -95,6 +95,8 @@ async def process_urls(headers, username, model_id, urls):
 
 
 def convert_num_bytes(num_bytes: int) -> str:
+    if num_bytes == 0:
+        return '0 B'
     num_digits = int(math.log10(num_bytes)) + 1
 
     if num_digits >= 10:


### PR DESCRIPTION
Passing zero into `math.log10()` raises a `ValueError`. 

However, we know that in the case of `num_bytes == 0` then the representation is `0 B`. 